### PR TITLE
make define_reference optional (as documented)

### DIFF
--- a/stemtool/afit/atom_positions.py
+++ b/stemtool/afit/atom_positions.py
@@ -920,6 +920,7 @@ class atom_fit(object):
         self.imshape = np.asarray(image.shape)
         self.peaks_check = False
         self.refining_check = False
+        self.reference_check = False
 
     def show_image(self, gaussval=0, imsize=(15, 15), colormap="inferno"):
         """


### PR DESCRIPTION
(it used to raise an AttributeError if you didn't call define_reference)